### PR TITLE
Adapt to fixed PawnIO installer

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -167,7 +167,7 @@ Exo relies on these runtimes, that you can download from the official websites:
 
 * .NET 9.0.202 runtime: https://dotnet.microsoft.com/en-us/download/dotnet/9.0
 * Windows App SDK 1.7 Runtime: https://aka.ms/windowsappsdk/1.7/1.7.250310001/windowsappruntimeinstall-x64.exe
-* PawnIO 2.0.0: https://github.com/namazso/PawnIO.Setup/releases/download/2.0.0/PawnIO_setup.exe
+* PawnIO 2: https://pawnio.eu/
 
 ℹ️ PawnIO is used for accessing low-level platform features in a safe way.
 You will need it to get things like CPU temperature sensors working.

--- a/src/Exo/Devices/Exo.Devices.Intel.Cpu/PawnIo.cs
+++ b/src/Exo/Devices/Exo.Devices.Intel.Cpu/PawnIo.cs
@@ -61,7 +61,7 @@ internal sealed class PawnIo : IDisposable
 	{
 		// There might be a problem with the installer, as on my system, the registry key ended up in the WoW64 world…
 #pragma warning disable CA1416 // Validate platform compatibility
-		if ((Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\PawnIO", "Install_Dir", null) ??
+		if ((Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO", "InstallLocation", null) ??
 			Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\PawnIO", "Install_Dir", null)) is string { Length: > 0 } pawnIoPath)
 		{
 			try


### PR DESCRIPTION
I just wrote a new installer from scratch since the old one was broken in more ways than the WOW64 keys, like the service API having zero error handling as it's clunky in NSIS. While at it, since the path never was correct, I also took the liberty to just use the (now also correctly placed) Uninstall key's one.

I also edited the readme to just point at the main site, as it's intended to be the landing page for end users, but feel free to drop that commit if you want.